### PR TITLE
improvements on the linesearch algorithm

### DIFF
--- a/examples/zsm12.py
+++ b/examples/zsm12.py
@@ -137,6 +137,11 @@ distance_dict = {
     'OO': {'mu' : 2.604, 'sigma' : 0.025},
     'SiSi': { 'mu' : 3.101, 'sigma' : 0.041}
 }
+# distance_dict = {
+#       'SiO': {'mu' : 1.6, 'sigma' : 0.01},
+#     'OO': {'mu' : 2.61, 'sigma' : 0.02},
+#     'SiSi': { 'mu' : 3.1, 'sigma' : 0.05}
+# }
 zeolite_dists = Distance_Function(distance_dict)
 
 print(f'There are {3*len(get_unique_indicies(s))} degrees of freedom')
@@ -146,7 +151,7 @@ gn = Gauss_Newton_Solver(
     structure=s,
     data_dictionary=data,
     max_iter=20,
-    tolerance_difference=1e-6 #-10
+    tolerance_difference=1e-10
     )
 
 test = pd.DataFrame(gn.fit()).sort_values(by = 'chi', ascending=True)

--- a/nmrcryspy/__init__.py
+++ b/nmrcryspy/__init__.py
@@ -147,7 +147,7 @@ class Gauss_Newton_Solver:
                 UNIQUE_IND
                 )
 
-            print(f"Round {k}: chi2 {phi/81}")
+            print(f"Round {k}: chi2 {phi/len(res)}")
             if self.tolerance_difference is not None:
                 diff = np.abs(chi2_prev - phi)
                 if diff < self.tolerance_difference:


### PR DESCRIPTION
Improved the Wolfe line search algorithm. Fixed an error with the cubic interpolation that caused divide by zero errors. New method attempts a cubic interpolation followed by quadratic interpolation followed by linear interpolation. Also improved efficiency by reusing phi and d_phi values rather than recalculating at each iteration